### PR TITLE
add handling for reference URIs; add notes to input widgets

### DIFF
--- a/MetadataManager/manager/metadata/aardvark_schema.json
+++ b/MetadataManager/manager/metadata/aardvark_schema.json
@@ -583,7 +583,7 @@
         "schema": "Aardvark",
         "display_group": "Links",
         "slug": "references",
-        "widget": "text-area.html"
+        "widget": "references.html"
     },
     "wxs_indentifier": {
         "label": "WxS Identifier",

--- a/MetadataManager/manager/model.py
+++ b/MetadataManager/manager/model.py
@@ -70,9 +70,7 @@ class RecordModel(db.Model):
         result = {}
         for i in self.__table__.columns:
             value = getattr(self, i.name)
-            if i.name == "references" and value is not None:
-                pass
-            elif i.name == "modified" and value is not None:
+            if i.name == "modified" and value is not None:
                 value = value.strftime("%Y-%m-%dT%H:%M:%SZ")
             elif FIELD_LOOKUP[i.name]['multiple'] and value is not None and not isinstance(value, int):
                 value = value.split("|")
@@ -85,8 +83,16 @@ class RecordModel(db.Model):
         data = {}
         for k, v in self.to_json().items():
             value = "" if v is None else v
+            if k == "references" and isinstance(value, dict):
+                lines = ""
+                for x, y in value.items():
+                    lines += f"{x}:: {y}\n"
+                value = lines
             if FIELD_LOOKUP[k]['multiple'] and isinstance(value, list):
-                value = "|".join(value)
+                if FIELD_LOOKUP[k].get('widget') == "text-area.html":
+                    value = "\n".join(value)
+                else:
+                    value = "|".join(value)
             data[k] = value
         return data
 

--- a/MetadataManager/manager/templates/widgets/_base.html
+++ b/MetadataManager/manager/templates/widgets/_base.html
@@ -8,6 +8,7 @@
                     <a href="https://opengeometadata.org/ogm-aardvark/#{{ field['slug'] }}" target="_blank">&nearr;</a>
                 {% endif %}
             </label>
+            {% block note %}{% endblock %}
         </div>
         <div class="col-9">
         {% block input %}{% endblock %}

--- a/MetadataManager/manager/templates/widgets/references.html
+++ b/MetadataManager/manager/templates/widgets/references.html
@@ -1,7 +1,9 @@
 {% extends 'widgets/_base.html' %}
 
 {% block note %}
-<p><em>put multiple values on separate lines</em></p>
+<p><em>put multiple references on separate lines, with this format:
+    <code>reference uri:: value</code>
+</em></p>
 {% endblock %}
 
 {% block input %}

--- a/MetadataManager/manager/templates/widgets/select.html
+++ b/MetadataManager/manager/templates/widgets/select.html
@@ -1,5 +1,11 @@
 {% extends 'widgets/_base.html' %}
 
+{% block note %}
+{% if field['multiple'] %}
+<p><em>ctrl + click to select/deselect</em></p>
+{% endif %}
+{% endblock %}
+
 {% block input %}
 <select class="form-select" name="{{ field['column_name'] }}"
     placeholder="" 

--- a/MetadataManager/manager/templates/widgets/text-simple.html
+++ b/MetadataManager/manager/templates/widgets/text-simple.html
@@ -1,5 +1,11 @@
 {% extends 'widgets/_base.html' %}
 
+{% block note %}
+{% if field['multiple'] %}
+<p><em>use | to separate values</em></p>
+{% endif %}
+{% endblock %}
+
 {% block input %}
 <input class="form-control" type="text" name="{{ field['column_name'] }}"
     placeholder="" {% if record %}value="{{ record[field['column_name']] }}"{% endif %}


### PR DESCRIPTION
Full handling of the squirrelly `references` json field. Values are added on multiple lines like so:

![image](https://github.com/healthyregions/SDOHPlace-MetadataManager/assets/10427268/fd9051e6-ba97-415d-9261-9b14825710dc)

Note `::` so as not to conflict with `:` in urls.

Also adds some input notes to the widgets for extra guidance to users.