### PR TITLE
#17: Update setup script to enable ping

### DIFF
--- a/scripts/setup_solr_core.sh
+++ b/scripts/setup_solr_core.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/bash
 
+set -e # exit if error
+
+if [ -z "$1" ]; then
+    echo "Error: Please provide a core name"
+    exit 1
+fi
+
 THIS_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 sudo su - solr -c "/opt/solr/bin/solr create -c $1 -n data_driven_schema_configs"
@@ -9,4 +16,10 @@ sudo cp $THIS_DIR/../solr/conf /var/solr/data/$1/ -r
 
 sudo sed -i -e "s/{{SOLR_CORE}}/$1/g" /var/solr/data/$1/conf/solrconfig.xml
 
+sudo mkdir -p /var/solr/data/$1/data
+sudo touch /var/solr/data/$1/data/server-enabled.txt
+sudo chown -R solr:solr /var/solr/data/$1/data
+
 sudo service solr restart
+
+echo "Successfully created core $1 and enabled PING"


### PR DESCRIPTION
This PR is for #17. It updates the setup scripts to enable ping when a new core is created.

## How to Test

1.Run `./setup_solr_core.sh CORE_NAME` to create a new core.

2. After the script runs successfully, you should see the message: "Successfully created core test-ping-core and enabled PING."

3. Go to the Solr admin (or check through `/admin/ping`). You should see that ping has been successfully enabled.