### PR TITLE
#33: update the Solr config to enable highlight and spellcheck

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -258,6 +258,7 @@
   <copyField source="dct_title_s"         dest="dct_title_ti"         maxChars="1000"/>
   <copyField source="dct_isPartOf_sm"    dest="dct_isPartOf_tmi"    maxChars="1000"/>
   <copyField source="id"       dest="layer_slug_ti"       maxChars="100"/>
+  <copyField source="dct_keyword_sm" dest="dct_keyword_tmi"  maxChars="1000" />
    <copyField source="sdoh_featured_variable_s" dest="sdoh_featured_variable_ti" maxChars="1000"/>
   
   <!-- core text search -->
@@ -284,7 +285,7 @@
   <copyField source="dct_isPartOf_sm"    dest="spell"/>
   <copyField source="sdoh_methods_variables_sm" dest="spell"/>
   <copyField source="sdoh_data_variables_sm" dest="spell"/>
-   <copyField source="sdoh_featured_variable_s" dest=
+  <copyField source="sdoh_featured_variable_s" dest="spell" />
 
   <!-- for suggestions (new SDOH setup) -->
   <copyField source="dct_title_s" dest="suggest" boost="100" />
@@ -296,7 +297,6 @@
   <copyField source="sdoh_featured_variable_s" dest="suggest" boost="80" />
   <copyField source="sdoh_methods_variables_sm" dest="suggest" boost="50" />
   <copyField source="sdoh_data_variables_sm" dest="suggest" boost="50" />
-   <copyField source="sdoh_featured_variable_s" dest="suggest" boost="80" />
 
   <!-- for payload -->
   <copyField source="gbl_suppressed_b" dest="gbl_suppressed_s"/>

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -34,6 +34,9 @@
     <field name="gbl_suppressed_s" type="string" stored="true" indexed="true"/>
     <field name="dct_description_sm" type="text_general" indexed="true" stored="true"
       multiValued="true" />
+    
+    <!-- highlights and selections -->
+    <field name="text_with_relationships" type="text_with_relationships" indexed="true" stored="true" multiValued="true" />
 
     <!-- dynamic field with simple types by suffix -->
     <dynamicField name="*_b"    type="boolean" stored="true"  indexed="true"/>
@@ -213,6 +216,32 @@
           replace="all" />
       </analyzer>
     </fieldType>
+
+    <!--   For relation handling   -->
+    <fieldType name="text_with_relationships" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
+          generateNumberParts="1" catenateWords="1" catenateNumbers="1" stemEnglishPossessive="1"
+          preserveOriginal="1" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.EnglishMinimalStemFilterFactory" />
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true"
+          expand="false" />
+        <filter class="solr.FlattenGraphFilterFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
+          generateNumberParts="1" catenateWords="1" catenateNumbers="1" stemEnglishPossessive="1"
+          preserveOriginal="1" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true"
+          expand="true" />
+      </analyzer>
+    </fieldType>
   </types>
 
   <!-- for scoring formula -->
@@ -229,6 +258,8 @@
   <copyField source="dct_title_s"         dest="dct_title_ti"         maxChars="1000"/>
   <copyField source="dct_isPartOf_sm"    dest="dct_isPartOf_tmi"    maxChars="1000"/>
   <copyField source="id"       dest="layer_slug_ti"       maxChars="100"/>
+  <copyField source="sdoh_methods_variables_sm" dest="sdoh_methods_variables_ti" maxChars="10000"/>
+  <copyField source="sdoh_data_variables_sm" dest="sdoh_data_variables_ti"  maxChars="10000" />
 
   <!-- core text search -->
   <copyField source="*_s"                dest="text" />
@@ -245,17 +276,15 @@
   <copyField source="schema_provider_s" dest="spell"/>
   <copyField source="dct_subject_sm" dest="spell"/>
   <copyField source="dct_spatial_sm" dest="spell"/>
-
-  <!-- for suggestions (default GBL setup) -->
-  <copyField source="dct_title_s" dest="suggest"/>
-  <copyField source="dct_creator_sm" dest="suggest"/>
-  <copyField source="dct_publisher_sm" dest="suggest"/>
-  <copyField source="schema_provider_s" dest="suggest"/>
-  <copyField source="dct_subject_sm" dest="suggest"/>
-  <!--<copyField source="dct_spatial_sm" dest="suggest"/>-->
-  <!-- add some SDOH fields to the default suggester -->
-  <copyField source="sdoh_methods_variables_sm" dest="suggest"/>
-  <copyField source="sdoh_data_variables_sm" dest="suggest"/>
+  <copyField source="dct_temporal_sm"    dest="spell"/>
+  <copyField source="dct_description_sm"   dest="spell"/>
+  <copyField source="dct_format_s"        dest="spell"/>
+  <copyField source="dct_identifier_sm"    dest="spell"/>
+  <copyField source="dct_publisher_sm"     dest="spell"/>
+  <copyField source="dct_accessRights_s"        dest="spell"/>
+  <copyField source="dct_isPartOf_sm"    dest="spell"/>
+  <copyField source="sdoh_methods_variables_sm" dest="spell"/>
+  <copyField source="sdoh_data_variables_sm" dest="spell"/>
 
   <!-- for suggestions (new SDOH setup) -->
   <copyField source="dct_title_s" dest="suggest" boost="100" />
@@ -268,22 +297,6 @@
   <copyField source="sdoh_methods_variables_sm" dest="suggest" boost="50" />
   <copyField source="sdoh_data_variables_sm" dest="suggest" boost="50" />
 
-  <!-- Unused booster -->
-  <!--
-  <copyField source="dct_title_s" dest="score" boost="100"/>
-  <copyField source="dct_description_sm" dest="score" boost="100"/>
-  <copyField source="dct_subject_sm" dest="score" boost="30"/>
-  <copyField source="dct_spatial_sm" dest="score" boost="0.1"/>
-  <copyField source="dct_creator_sm" dest="score" boost="20"/>
-  <copyField source="dct_publisher_sm" dest="score" boost="20"/>
-  <copyField source="schema_provider_s" dest="score" boost="20"/>
-  <copyField source="dct_keyword_sm" dest="score" boost="30"/>
-  <copyField source="sdoh_data_variables_sm" dest="suggest" boost="50"/>
-  <copyField source="sdoh_data_usage_notes_s" dest="score" boost="100"/>
-  <copyField source="sdoh_methods_variables_sm" dest="score" boost="50"/>
-  <copyField source="sdoh_data_variables_sm" dest="score" boost="50"/>
-  -->
-
   <!-- for payload -->
   <copyField source="gbl_suppressed_b" dest="gbl_suppressed_s"/>
   <copyField source="gbl_suppressed_s" dest="payload"/>
@@ -293,4 +306,18 @@
 
   <!-- for bbox value -->
   <copyField source="dcat_bbox" dest="solr_bboxtype"/>
+
+  <!--   for relationship handle  -->
+  <copyField source="dct_title_s" dest="text_with_relationships" />
+  <copyField source="dct_description_sm" dest="text_with_relationships" />
+  <copyField source="dct_subject_sm" dest="text_with_relationships" />
+  <copyField source="dct_creator_sm" dest="text_with_relationships" />
+  <copyField source="dct_publisher_sm" dest="text_with_relationships" />
+  <copyField source="dct_spatial_sm" dest="text_with_relationships" />
+  <copyField source="dct_temporal_sm" dest="text_with_relationships" />
+  <copyField source="dct_isPartOf_sm" dest="text_with_relationships" />
+  <copyField source="sdoh_data_variables_sm" dest="text_with_relationships" />
+  <copyField source="sdoh_data_usage_notes_s" dest="text_with_relationships" />
+  <copyField source="sdoh_methods_variables_sm" dest="text_with_relationships" />
+  <copyField source="dct_keyword_sm" dest="text_with_relationships" />
 </schema>

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -224,11 +224,11 @@
         <filter class="solr.LowerCaseFilterFactory" />
         <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
           generateNumberParts="1" catenateWords="1" catenateNumbers="1" stemEnglishPossessive="1"
-          preserveOriginal="1" />
+          preserveOriginal="1" splitOnCaseChange="1"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.EnglishMinimalStemFilterFactory" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true"
-          expand="false" />
+          expand="true" />
         <filter class="solr.FlattenGraphFilterFactory" />
       </analyzer>
       <analyzer type="query">
@@ -258,9 +258,8 @@
   <copyField source="dct_title_s"         dest="dct_title_ti"         maxChars="1000"/>
   <copyField source="dct_isPartOf_sm"    dest="dct_isPartOf_tmi"    maxChars="1000"/>
   <copyField source="id"       dest="layer_slug_ti"       maxChars="100"/>
-  <copyField source="sdoh_methods_variables_sm" dest="sdoh_methods_variables_ti" maxChars="10000"/>
-  <copyField source="sdoh_data_variables_sm" dest="sdoh_data_variables_ti"  maxChars="10000" />
-
+   <copyField source="sdoh_featured_variable_s" dest="sdoh_featured_variable_ti" maxChars="1000"/>
+  
   <!-- core text search -->
   <copyField source="*_s"                dest="text" />
   <copyField source="*_sm"               dest="text" />
@@ -285,6 +284,7 @@
   <copyField source="dct_isPartOf_sm"    dest="spell"/>
   <copyField source="sdoh_methods_variables_sm" dest="spell"/>
   <copyField source="sdoh_data_variables_sm" dest="spell"/>
+   <copyField source="sdoh_featured_variable_s" dest=
 
   <!-- for suggestions (new SDOH setup) -->
   <copyField source="dct_title_s" dest="suggest" boost="100" />
@@ -296,6 +296,7 @@
   <copyField source="sdoh_featured_variable_s" dest="suggest" boost="80" />
   <copyField source="sdoh_methods_variables_sm" dest="suggest" boost="50" />
   <copyField source="sdoh_data_variables_sm" dest="suggest" boost="50" />
+   <copyField source="sdoh_featured_variable_s" dest="suggest" boost="80" />
 
   <!-- for payload -->
   <copyField source="gbl_suppressed_b" dest="gbl_suppressed_s"/>
@@ -320,4 +321,5 @@
   <copyField source="sdoh_data_usage_notes_s" dest="text_with_relationships" />
   <copyField source="sdoh_methods_variables_sm" dest="text_with_relationships" />
   <copyField source="dct_keyword_sm" dest="text_with_relationships" />
+  <copyField source="sdoh_featured_variable_s" dest="text_with_relationships"/>
 </schema>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -116,36 +116,27 @@
       <str name="sort">score desc, dct_title_sort asc</str>
       <str name="q.alt">*:*</str>
       <str name="qf">
-        text^1
-        dct_description_ti^2
+        text^10
+        text_with_relationships^9
+        dct_description_ti^9
         dct_creator_tmi^3
         dct_publisher_ti^3
         dct_isPartOf_tmi^4
         dct_subject_tmi^5
         dct_spatial_tmi^5
-        dct_temporal_tmi^5
-        dct_title_ti^6
+        dct_temporal_tmi^6
+        dct_title_ti^10
         dct_accessRights_ti^7
-        dct_provider_ti^8
-        layer_geom_type_ti^9
-        layer_slug_ti^10
-        dct_identifier_ti^10
+        dct_provider_ti^4
+        layer_geom_type_ti^3
+        layer_slug_ti^2
+        dct_identifier_ti^2
       </str>
       <str name="pf"><!-- phrase boost within result set -->
-        text^1
-        dct_description_ti^2
-        dct_creator_tmi^3
-        dct_publisher_ti^3
-        dct_isPartOf_tmi^4
-        dct_subject_tmi^5
-        dct_spatial_tmi^5
-        dct_temporal_tmi^5
-        dct_title_ti^6
-        dct_accessRights_ti^7
-        dct_provider_ti^8
-        layer_geom_type_ti^9
-        layer_slug_ti^10
-        dct_identifier_ti^10
+        text^10
+        text_with_relationships^9
+        dct_description_ti^9
+        dct_title_ti^10
       </str>
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>
@@ -161,7 +152,21 @@
       <str name="facet.field">dct_subject_sm</str>
       <str name="facet.field">locn_geometry_s</str>
       <str name="facet.field">gbl_indexYear_im</str>
-
+      <!-- highlights -->
+      <str name="hl">true</str>
+      <str name="hl.fl">*</str>
+      <str name="hl.method">unified</str>
+      <str name="hl.simple.pre">
+      <![CDATA[ <strong> ]]>
+      </str>
+      <str name="hl.simple.post">
+      <![CDATA[ </strong> ]]>
+      </str>
+      <str name="hl.snippets">5</str>
+      <str name="hl.fragsize">300</str>
+      <str name="hl.maxAnalyzedChars">100000</str>
+      <str name="hl.alternateField">dct_title_s</str>
+      <!-- spellcheck -->
       <str name="spellcheck">true</str>
     </lst>
     <arr name="last-components">
@@ -216,17 +221,16 @@
   </searchComponent>
 
 <searchComponent name="suggest" class="solr.SuggestComponent">
-    <!-- This is the default GeoBlacklight suggester -->
+    <!-- This is the default GeoBlacklight suggester
     <lst name="suggester">
       <str name="name">mySuggester</str>
       <str name="lookupImpl">FuzzyLookupFactory</str>
       <str name="suggestAnalyzerFieldType">textSuggest</str>
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
-      <!-- new props -->
       <str name="preserveSep">false</str>
       <str name="payloadField">sdoh_data_variables_sm</str>
-    </lst>
+    </lst>-->
      <!--This is a new suggester for SDOH project-->
      <lst name="suggester">
       <str name="name">sdohSuggester</str>
@@ -243,39 +247,7 @@
       <int name="minPrefixChars">1</int>
       <bool name="highlight">true</bool>
     </lst>
-    <!--HighFrequencyDictionaryFactory version with different score but no payloads. Not use this one for now-->
-    <!--<lst name="suggester">
-        <str name="name">sdohSuggester</str>
-        <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
-        <str name="dictionaryImpl">HighFrequencyDictionaryFactory</str>
-        <str name="field">suggest</str>
-        <str name="suggestAnalyzerFieldType">text_suggest</str>
-        <str name="weightField">score</str>
-        <bool name="exactMatchFirst">false</bool>
-        <str name="buildOnStartup">true</str>
-        <str name="buildOnCommit">true</str>
-        <int name="minPrefixChars">1</int>
-        <bool name="highlight">true</bool>
-        <bool name="allTermsRequired">true</bool>
-        <str name="payloadField">dct_title_s</str>
-    </lst>-->
-  </searchComponent> 
-
-  <!-- Here's another suggester to try for internal matching, based on this SE answer:
-  https://stackoverflow.com/a/40185213 -->
-  <!--
-  <searchComponent name="suggest" class="solr.SuggestComponent">
-    <lst name="suggester">
-      <str name="name">infixSuggester</str>
-      <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
-      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
-      <str name="field">suggest_field</str>
-      <str name="weightField">price</str>
-      <str name="suggestAnalyzerFieldType">suggest_type</str>
-      <str name="buildOnStartup">false</str>
-    </lst>
   </searchComponent>
-  -->
   <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
     <lst name="defaults">
       <str name="suggest">true</str>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -133,7 +133,6 @@
         dct_identifier_ti^2
       </str>
       <str name="pf"><!-- phrase boost within result set -->
-        text^10
         text_with_relationships^9
         dct_description_ti^9
         dct_title_ti^10
@@ -154,7 +153,8 @@
       <str name="facet.field">gbl_indexYear_im</str>
       <!-- highlights -->
       <str name="hl">true</str>
-      <str name="hl.fl">*</str>
+      <str name="hl.fl"> dct_subject_sm,sdoh_featured_variable_s,text_with_relationships,dct_description_sm,dct_title_s,dct_keyword_sm, sdoh_methods_variables_sm, sdoh_data_usage_notes_s, sdoh_data_variables_sm, dct_creator_sm, dct_publisher_s</str>
+      <str name="hl.bs.type">WORD</str>
       <str name="hl.method">unified</str>
       <str name="hl.simple.pre">
       <![CDATA[ <strong> ]]>
@@ -165,7 +165,11 @@
       <str name="hl.snippets">5</str>
       <str name="hl.fragsize">300</str>
       <str name="hl.maxAnalyzedChars">100000</str>
-      <str name="hl.alternateField">dct_title_s</str>
+      <str name="hl.highlightMultiTerm">true</str>
+      <str name="hl.usePhraseHighlighter">true</str>
+      <str name="hl.mergeContiguous">true</str>
+      <str name="hl.preserveMulti">true</str>
+      <str name="hl.multiTermQuery">rewrite</str>
       <!-- spellcheck -->
       <str name="spellcheck">true</str>
     </lst>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -124,13 +124,14 @@
         dct_isPartOf_tmi^4
         dct_subject_tmi^5
         dct_spatial_tmi^5
-        dct_temporal_tmi^6
+        dct_temporal_tmi^5
         dct_title_ti^10
-        dct_accessRights_ti^7
+        dct_accessRights_ti^6
         dct_provider_ti^4
         layer_geom_type_ti^3
         layer_slug_ti^2
         dct_identifier_ti^2
+        dct_keyword_sm_tmi^7
       </str>
       <str name="pf"><!-- phrase boost within result set -->
         text_with_relationships^9

--- a/solr/conf/synonyms.txt
+++ b/solr/conf/synonyms.txt
@@ -10,22 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#-----------------------------------------------------------------------
-#some test synonym mappings unlikely to appear in real input text
-aaa => aaaa
-bbb => bbbb1 bbbb2
-ccc => cccc1,cccc2
-a\=>a => b\=>b
-a\,a => b\,b
-fooaaa,baraaa,bazaaa
+# SDOH bidirectional synonyms
+sdoh,social determinants of health,social determinants
 
-# Some synonym groups specific to this example
-GB,gib,gigabyte,gigabytes
-MB,mib,megabyte,megabytes
-Television, Televisions, TV, TVs
-#notice we use "gib" instead of "GiB" so any WordDelimiterFilter coming
-#after us won't split it into two words.
-
-# Synonym mappings can be used for spelling correction too
-pixima => pixma
-
+# SDOH hierarchical relationship (unidirectional)
+sdoh => sdoh,social vulnerability

--- a/solr/conf/synonyms.txt
+++ b/solr/conf/synonyms.txt
@@ -11,7 +11,22 @@
 # limitations under the License.
 
 # SDOH bidirectional synonyms
-sdoh,social determinants of health,social determinants
+sdoh,social determinants of health,social determinants,health determinants
+health equity,healthcare equity,health equality
+economic stability,income stability,financial security,economic security
+education access,educational opportunity,education quality
+healthcare access,health care access,access to care,healthcare availability
+neighborhood environment,built environment,environmental conditions
+social context,social support,community context
+food security,food access,food availability
+housing stability,housing security,housing access
+transportation access,transit access,transportation availability
 
 # SDOH hierarchical relationship (unidirectional)
-sdoh => sdoh,social vulnerability
+sdoh => social vulnerability,health equity
+poverty => economic stability,income stability,financial hardship
+literacy => education access,education quality,educational attainment
+healthcare disparities => health equity,healthcare access,care availability
+environmental justice => neighborhood environment,built environment,environmental health
+social vulnerability => sdoh,health equity,social determinants of health
+health disparities => sdoh,health equity,healthcare access


### PR DESCRIPTION
This PR addresses #33 and includes the following Solr updates:

1. Enabling the Spellcheck feature (#35).
2. Adjusting the scoring method to boost critical fields and include term relationship tests.
3. Enabling the highlight feature and configuring it to trial-run term relationship navigation.
4. Issue #32 has already been resolved in the main branch version and can be closed.

For the reflected results, see https://github.com/healthyregions/SDOHPlace/pull/413.