### PR TITLE
#38: update sorting rule on All searches

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -174,6 +174,10 @@
       <!-- spellcheck -->
       <str name="spellcheck">true</str>
     </lst>
+    <lst name="appendss">
+        <str name="q.alt">*:*</str>
+        <str name="sort">dct_title_s asc</str>
+    </lst>
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>


### PR DESCRIPTION
This PR addresses issue #38. It appends a new rule to enforce sorting 'All' matches by Title. Please note that https://github.com/healthyregions/SDOHPlace/pull/417 is always required for the front-end to accommodate this change.