### PR TITLE
feat: first-pass at handling "download/<label>:: <url>" as an array

### DIFF
--- a/manager/metadata/records/sdoh-indices.json
+++ b/manager/metadata/records/sdoh-indices.json
@@ -3,8 +3,8 @@
     "created_by": "",
     "last_modified_by": "Admin",
     "filled": 20,
-    "to_fill": 25,
-    "filled_pct": 80,
+    "to_fill": 26,
+    "filled_pct": 76,
     "progress_class": "warning"
   },
   "id": "herop-yvjqrx",
@@ -83,11 +83,11 @@
   "file_size": null,
   "references": {
     "http://schema.org/url": "https://sdohatlas.github.io/",
-    "http://schema.org/downloadUrl": "[{'url': 'https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip', 'label': 'ZIP Archive'}]"
+    "http://schema.org/downloadUrl": "[{\"label\": \"ZIP Archive\", \"url\": \"https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip\"}]"
   },
   "wxs_indentifier": null,
   "identifier": null,
-  "modified": "2025-02-03T21:05:47Z",
+  "modified": "2025-02-20T21:26:18Z",
   "metadata_version": "SDOH PlaceProject",
   "suppressed": false,
   "spatial_resolution": [
@@ -139,6 +139,9 @@
     "SDOH_CL - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas"
   ],
   "highlight_ids": null,
-  "featured_variable": "Socioeconomic Advantage Index, Limited Mobility Index, Urban Core Opportunity Index, Mixed Immigrant, Cohesion, & Access Index, SDOH Cluster - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas (see https://sdohatlas.github.io/)",
-  "data_usage_notes": null
+  "featured_variable": [
+    "Socioeconomic Advantage Index, Limited Mobility Index, Urban Core Opportunity Index, Mixed Immigrant, Cohesion, & Access Index, SDOH Cluster - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas (see https://sdohatlas.github.io/)"
+  ],
+  "data_usage_notes": null,
+  "preferred_citation": null
 }

--- a/manager/metadata/records/sdoh-indices.json
+++ b/manager/metadata/records/sdoh-indices.json
@@ -83,11 +83,16 @@
   "file_size": null,
   "references": {
     "http://schema.org/url": "https://sdohatlas.github.io/",
-    "http://schema.org/downloadUrl": "[{\"label\": \"ZIP Archive\", \"url\": \"https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip\"}]"
+    "http://schema.org/downloadUrl": [
+      {
+        "label": "ZIP Archive",
+        "url": "https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip"
+      }
+    ]
   },
   "wxs_indentifier": null,
   "identifier": null,
-  "modified": "2025-02-20T21:26:18Z",
+  "modified": "2025-02-24T17:30:29Z",
   "metadata_version": "SDOH PlaceProject",
   "suppressed": false,
   "spatial_resolution": [

--- a/manager/metadata/records/sdoh-indices.json
+++ b/manager/metadata/records/sdoh-indices.json
@@ -3,8 +3,8 @@
     "created_by": "",
     "last_modified_by": "Admin",
     "filled": 20,
-    "to_fill": 26,
-    "filled_pct": 76,
+    "to_fill": 25,
+    "filled_pct": 80,
     "progress_class": "warning"
   },
   "id": "herop-yvjqrx",
@@ -83,16 +83,11 @@
   "file_size": null,
   "references": {
     "http://schema.org/url": "https://sdohatlas.github.io/",
-    "http://schema.org/downloadUrl": [
-      {
-        "label": "ZIP Archive",
-        "url": "https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip"
-      }
-    ]
+    "http://schema.org/downloadUrl": "[{'url': 'https://geodacenter.github.io/data-and-lab/data/us-sdoh-2014.zip', 'label': 'ZIP Archive'}]"
   },
   "wxs_indentifier": null,
   "identifier": null,
-  "modified": "2025-02-24T17:30:29Z",
+  "modified": "2025-02-03T21:05:47Z",
   "metadata_version": "SDOH PlaceProject",
   "suppressed": false,
   "spatial_resolution": [
@@ -144,9 +139,6 @@
     "SDOH_CL - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas"
   ],
   "highlight_ids": null,
-  "featured_variable": [
-    "Socioeconomic Advantage Index, Limited Mobility Index, Urban Core Opportunity Index, Mixed Immigrant, Cohesion, & Access Index, SDOH Cluster - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas (see https://sdohatlas.github.io/)"
-  ],
-  "data_usage_notes": null,
-  "preferred_citation": null
+  "featured_variable": "Socioeconomic Advantage Index, Limited Mobility Index, Urban Core Opportunity Index, Mixed Immigrant, Cohesion, & Access Index, SDOH Cluster - 1:rural affordable, 2:suburban affluent, 3:suburban affordable, 4:extreme poverty, 5:multilingual working, 6:urban core opportunity, 7:sparse areas (see https://sdohatlas.github.io/)",
+  "data_usage_notes": null
 }

--- a/manager/registry.py
+++ b/manager/registry.py
@@ -148,7 +148,7 @@ class Record:
                     cleaned_references[k.rstrip().lstrip()] = v.rstrip().lstrip()
 
             if len(download_refs) > 0:
-                cleaned_references['http://schema.org/downloadUrl'] = json.dumps(download_refs)
+                cleaned_references['http://schema.org/downloadUrl'] = download_refs
             self.data["references"] = cleaned_references
 
         coverages = (
@@ -231,11 +231,10 @@ class Record:
                     logging.warning(f'item - {x}:: {y}')
                     if x == 'http://schema.org/downloadUrl':
                         try:
-                            y_parsed = json.loads(y)
-                            if isinstance(y_parsed, list):
+                            if isinstance(y, list):
                                 # downloadUrl is a list of objects defining label + url
                                 # break it up into multiple lines of download/<label>:: <url>
-                                for u in y_parsed:
+                                for u in y:
                                     lines += f"download/{u['label']}:: {u['url']}\n"
                         except JSONDecodeError as ex:
                             # downloadUrl is a single string

--- a/manager/registry.py
+++ b/manager/registry.py
@@ -215,25 +215,6 @@ class Record:
 
         self.data["_meta"] = meta
 
-        # cleaned_references = {}
-        # download_refs = []
-        # refs = self.data["references"]
-        # if refs and len(refs) > 0:
-        #     for k, v in refs.items():
-        #         if k.startswith('download/'):
-        #             ref = {'label': k[9:], 'url': v}
-        #             #print(f'Adding references: {str(ref)}')
-        #             download_refs.append(ref)
-        #         else:
-        #             cleaned_references[k] = v
-        #
-        #         if len(download_refs) > 0:
-        #             cleaned_references['http://schema.org/downloadUrl'] = json.dumps(download_refs)
-        #
-        #         #if k.startswith('download/'):
-        #         #    print(cleaned_references)
-        #     self.data["references"] = cleaned_references
-
         return self.data
 
 
@@ -252,17 +233,14 @@ class Record:
                         try:
                             y_parsed = json.loads(y)
                             if isinstance(y_parsed, list):
-                                print('Dictionary found')
                                 # downloadUrl is a list of objects defining label + url
                                 # break it up into multiple lines of download/<label>:: <url>
                                 for u in y_parsed:
                                     lines += f"download/{u['label']}:: {u['url']}\n"
                         except JSONDecodeError as ex:
                             # downloadUrl is a single string
-                            print('String found')
                             lines += f"{x}:: {y}\n"
                     else:
-                        print('Typical key found')
                         lines += f"{x}:: {y}\n"
                 value = lines
             if field.multiple and isinstance(value, list):
@@ -282,22 +260,6 @@ class Record:
             if value is not None and str(value).lower() != "none":
                 if key == "references":
                     value = json.dumps(value)
-                    # non_download_refs = {k:v for k, v in value.items() if not k.startswith("download/")}
-                    # download_refs = [{
-                    #     'label': k[9:],
-                    #     'url': v,
-                    # } for k, v in value.items() if k.startswith("download/")]
-                    # download_ref_formatted = {'http://schema.org/downloadUrl': download_refs}
-                    # if len(non_download_refs) > 0:
-                    #     print('Non Download Refs:')
-                    #     print(non_download_refs)
-                    #
-                    # if len(download_refs) > 0:
-                    #     print('Download Refs:')
-                    #     print(download_ref_formatted)
-                    #     value = {**non_download_refs, **download_ref_formatted}
-                    # else:
-                    #     value = non_download_refs
                 solr_doc[field.uri] = value
         return solr_doc
 

--- a/manager/registry.py
+++ b/manager/registry.py
@@ -234,8 +234,20 @@ class Record:
             value = self.data.get(key)
             if value is not None and str(value).lower() != "none":
                 if key == "references":
-                    value = json.dumps(value)
-                solr_doc[field.uri] = value
+                    non_download_refs = {k:v for k, v in value.items() if not str.startswith(k, "download/")}
+                    download_refs = [{
+                        'label': k[9:],
+                        'url': v,
+                    } for k, v in value.items() if str.startswith(k, "download/")]
+                    download_ref_formatted = {'http://schema.org/downloadUrl': download_refs}
+                    #print(non_download_refs)
+                    if len(download_refs) > 0:
+                        #print(download_ref_formatted)
+                        value = {**non_download_refs, **download_ref_formatted}
+                    else:
+                        value = non_download_refs
+                    print(json.dumps(value))
+                solr_doc[field.uri] = json.dumps(value)
         return solr_doc
 
     def index(self, solr_instance=None):

--- a/manager/templates/crud/widgets/references.html
+++ b/manager/templates/crud/widgets/references.html
@@ -4,6 +4,10 @@
 put multiple references on separate lines, with this format: <code>&lt;reference uri&gt;:: &lt;value&gt;</code> where <code>reference uri</code> is one of <a href="https://opengeometadata.org/reference-uris/" target="_blank">these options &nearr;</a>
 {% endblock %}
 
+{% block format %}
+specify multiple download formats using <code>download/&lt;label&gt;:: &lt;url&gt;</code> where <code>label</code> is <code>CSV</code>, <code>JSON</code>, <code>XML</code>, etc.
+{% endblock %}
+
 {% block input %}
 <textarea 
 style="white-space:pre; overflow-wrap:normal; overflow-x:scroll; width:100%;"

--- a/manager/templates/crud/widgets/references.html
+++ b/manager/templates/crud/widgets/references.html
@@ -2,10 +2,8 @@
 
 {% block note %}
 put multiple references on separate lines, with this format: <code>&lt;reference uri&gt;:: &lt;value&gt;</code> where <code>reference uri</code> is one of <a href="https://opengeometadata.org/reference-uris/" target="_blank">these options &nearr;</a>
-{% endblock %}
-
-{% block format %}
-specify multiple download formats using <code>download/&lt;label&gt;:: &lt;url&gt;</code> where <code>label</code> is <code>CSV</code>, <code>JSON</code>, <code>XML</code>, etc.
+<br>
+specify multiple download formats using <code>download/&lt;label&gt;:: &lt;url&gt;</code> where <code>label</code> is a unique string, such as <code>CSV</code>, <code>JSON</code>, <code>XML</code>, etc.
 {% endblock %}
 
 {% block input %}


### PR DESCRIPTION
## Problem
We would like to track multiple download links in the `references` field - ideally this would let us offer different data formats for download

Our current field support a single key-value pair for the download URL, but we want to expand this to support a list of URLs + labels for tracking different formats

Fixes #44 

## Approach
* feat: first-pass at supporting a list of download links in different formats
* fix: tested loading/editing/saving different formats
* fix: adjust existing `downloadUrl` list format to match new pattern (see `sdoh-indices.json`) 

We now support a list of values under the key `http://schema.org/downloadUrl`

### Format
Expected format: `download/<label>:: <url>` 

Each entry matching the above format with a unique label will be converted into a list of url+label pairs
For example, `download/asdf:: 123456` becomes `'http://schema.org/downloadUrl': [{'label':'asdf', 'url':'123456'}]`

### Precedence
This format will take precedence over a single URL - if the user specifies the following conflicting entries:
```
http://schema.org/downloadUrl:: 654321
download/asdf:: 123456
``` 

Only the special syntax will be recognized, and overwritten to use JSON instead:
```
{'http://schema.org/downloadUrl': [{'label': 'asdf', 'url': '123456'}]}
```

If no other entries use this special format, then `http://schema.org/downloadUrl` can still be used for normal key-value pairs

## How to Test
1. Checkout and run this branch locally, start up the MetadataManager
2. Navigate to your local MetadataManager in the browser
    * You should see a list of metadata entries
3. Locate a metadata entry and click on it
    * You should be brought to the "View" view
4. At the top-right, click on the Edit button
    * You should be brought to the "Edit" view
5. Scroll down to the `References` section and enter the following contents:
```
http://schema.org/url:: https://sdohatlas.github.io/
http://schema.org/downloadUrl:: http://example.com/download
download/ZIP:: http://example.com/download?format=zip
download/CSV:: http://example.com/download?format=csv
download/XML:: http://example.com/download?format=xml
```
6. Scroll back up and click Save at the top-right
7. Scroll back down to References to see the format that was saved
    * You should see that `http://schema.org/url` is a classic key-value that gets preserved
    * You should see that the three `download/<label>` special syntax entries were transformed into a JSON array of objects
    * You should see that the key-value form of `http://schema.org/downloadUrl` was ignored, because the special syntax entries overwrote it
    * You should see the following value/format was saved:
```
{'http://schema.org/url': 'https://sdohatlas.github.io/', 'http://schema.org/downloadUrl': [{'label': 'ZIP', 'url': 'http://example.com/download?format=zip'}, {'label': 'CSV', 'url': 'http://example.com/download?format=csv'}, {'label': 'XML', 'url': 'http://example.com/download?format=xml'}]}
```