### PR TITLE
implement new ordered multi-select widget for Subject

### DIFF
--- a/manager/metadata/schemas/sdohplace.json
+++ b/manager/metadata/schemas/sdohplace.json
@@ -334,7 +334,7 @@
             "schema": "Aardvark",
             "display_group": "Categories",
             "slug": "subject",
-            "widget": "checkboxes.html",
+            "widget": "ordered-multi-select.html",
             "id": "subject"
         },
         {

--- a/manager/registry.py
+++ b/manager/registry.py
@@ -293,6 +293,9 @@ class Field:
         if value == "":
             value = None
 
+        if self.widget == "ordered-multi-select.html":
+            value = value.split("|") if value else None
+
         if self.widget == "checkboxes.html":
             value = [
                 k.split("--")[1]

--- a/manager/templates/crud/widgets/ordered-multi-select.html
+++ b/manager/templates/crud/widgets/ordered-multi-select.html
@@ -1,0 +1,30 @@
+{% extends 'crud/widgets/_base.html' %}
+
+{% block note %}
+use the dropdown to add a new value to the list
+{% endblock %}
+
+{% block input %}
+<div style="display:flex; flex-direction: column;">
+    <div style="display:flex;">
+        <select id="{{ field.id }}-select" name="{{ field.id }}-select" placeholder="">
+            {% for choice in field.controlled_options %}
+            <option value="{{ choice }}">{{ choice }}</option>
+            {% endfor %}
+        </select>
+        <div id="clear-button" style="cursor:pointer; margin-left:1em;">Click to clear existing values</div>
+    </div>
+    <input id="{{ field.id }}-selected" name="{{ field.id }}" readonly {% if record %}value="{{ record[field.id] }}"{% endif %} style="width:100%;"/>
+</div>
+<script>
+    const selected = document.getElementById("{{ field.id }}-selected");
+    document.getElementById("{{ field.id }}-select").addEventListener("change", (evt) => {
+        const vals = selected.value.split("|").filter(i => i)
+        if (!vals.includes(evt.target.value)) {vals.push(evt.target.value)}
+        selected.value = vals.join("|");
+    })
+    document.getElementById("clear-button").addEventListener("click", (evt) => {
+        selected.value = "";
+    })
+</script>
+{% endblock %}

--- a/manager/templates/crud/widgets/ordered-multi-select.html
+++ b/manager/templates/crud/widgets/ordered-multi-select.html
@@ -7,14 +7,19 @@ use the dropdown to add a new value to the list
 {% block input %}
 <div style="display:flex; flex-direction: column;">
     <div style="display:flex;">
-        <select id="{{ field.id }}-select" name="{{ field.id }}-select" placeholder="">
-            {% for choice in field.controlled_options %}
-            <option value="{{ choice }}">{{ choice }}</option>
-            {% endfor %}
-        </select>
-        <div id="clear-button" style="cursor:pointer; margin-left:1em;">Click to clear existing values</div>
+        <div class="select">
+            <select id="{{ field.id }}-select" name="{{ field.id }}-select" placeholder="">
+                {% for choice in field.controlled_options %}
+                <option value="{{ choice }}">{{ choice }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div id="clear-button" class="button is-danger" style="cursor:pointer; margin-left:1em;">Click to clear</div>
     </div>
-    <input id="{{ field.id }}-selected" name="{{ field.id }}" readonly {% if record %}value="{{ record[field.id] }}"{% endif %} style="width:100%;"/>
+    <div class="level">
+        <span style="text-wrap: nowrap;">Current value:</span>
+        <input id="{{ field.id }}-selected" class="input is-static" name="{{ field.id }}" readonly {% if record %}value="{{ record[field.id] }}"{% endif %} style="width:100%;"/>
+    </div>
 </div>
 <script>
     const selected = document.getElementById("{{ field.id }}-selected");


### PR DESCRIPTION
Create a basic pattern and widget for allowing multiple select items to be ordered. It's very basic:

1. A selection dropdown is generated from controlled values list in the schema
2. On selection, the value is added to an array that is stored in a readonly input element
3. A clear button empties to selection input
4. On form submission, existing patterns are used that expect values to be split by `|`

<img width="1611" height="274" alt="image" src="https://github.com/user-attachments/assets/13b6425a-24c1-479c-b2ee-1bf02334d5f7" />
